### PR TITLE
misc bugfixes

### DIFF
--- a/tests/integration/.env
+++ b/tests/integration/.env
@@ -1,0 +1,23 @@
+# The following hash corresponds to the image php:8.1.18-apache
+# php@sha256:5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471
+# it can be found here: https://hub.docker.com/layers/library/php/8.1.18-apache/images/sha256-5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471?context=explore
+PHP_HASH='php@sha256:5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471'
+
+# The following hash corresponds to the image mysql:8
+# mysql@sha256:13e429971e970ebcb7bc611de52d71a3c444247dc67cf7475a02718f6a5ef559
+# it can be found here: https://hub.docker.com/layers/library/mysql/8/images/sha256-13e429971e970ebcb7bc611de52d71a3c444247dc67cf7475a02718f6a5ef559?context=explore
+MYSQL_HASH='mysql@sha256:13e429971e970ebcb7bc611de52d71a3c444247dc67cf7475a02718f6a5ef559'
+
+# The following hashes corresponds respectively to the images, drupal:9-apache, drupal:10-apache
+# drupal@sha256:18692a0792c882957024f4086cadbc966778c5593850dfa89edb7780ba8b794d
+# drupal@sha256:d85280f104d6c8e1eff7e2613b5ee584d0a4105d54f4ffe352f945e38d095514
+# They can respectively be found at:
+# https://hub.docker.com/layers/library/drupal/9-apache/images/sha256-18692a0792c882957024f4086cadbc966778c5593850dfa89edb7780ba8b794d?context=explore
+# https://hub.docker.com/layers/library/drupal/10-apache/images/sha256-d85280f104d6c8e1eff7e2613b5ee584d0a4105d54f4ffe352f945e38d095514?context=explore
+DRUPAL9_HASH='drupal@sha256:18692a0792c882957024f4086cadbc966778c5593850dfa89edb7780ba8b794d'
+DRUPAL10_HASH='drupal@sha256:d85280f104d6c8e1eff7e2613b5ee584d0a4105d54f4ffe352f945e38d095514'
+# Some variables allowing the drupal instances and their DB to run
+DRUPAL_MYSQL_DB='drupal'
+DRUPAL_MYSQL_USER='drupal'
+DRUPAL_MYSQL_PASSWORD='drupalpasswd'
+DRUPAL_MYSQL_ROOT_PASSWORD='rootpasswd'

--- a/tests/integration/csrf/assertions/csrf.json
+++ b/tests/integration/csrf/assertions/csrf.json
@@ -7,14 +7,14 @@
         "Cross Site Request Forgery": [
             {
                 "method": "POST",
-                "path": "/csrf_verify_unprotected.php",
-                "info": "Lack of anti CSRF token",
+                "path": "/fake_protected_form.php",
+                "info": "CSRF token 'csrf_token' might be easy to predict",
                 "level": 2,
                 "parameter": "",
-                "referer": "http://csrf/unprotected_form.php",
+                "referer": "http://csrf/fake_protected_form.php",
                 "module": "csrf",
-                "http_request": "POST /csrf_verify_unprotected.php HTTP/1.1\nhost: csrf\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\ncontent-type: application/x-www-form-urlencoded\nreferer: http://csrf/unprotected_form.php\ncookie: PHPSESSID=1335df1b1b4a2149e8690c7ce5\ncontent-length: 12\nContent-Type: application/x-www-form-urlencoded\n\nname=default",
-                "curl_command": "curl \"http://csrf/csrf_verify_unprotected.php\" -e \"http://csrf/unprotected_form.php\" -d \"name=default\"",
+                "http_request": "POST /fake_protected_form.php HTTP/1.1\ncontent-type: application/x-www-form-urlencoded, application/x-www-form-urlencoded\nhost: csrf\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\nreferer: http://csrf/fake_protected_form.php\ncookie: PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932\ncontent-length: 39\nContent-Type: application/x-www-form-urlencoded\n\ncsrf_token=AAAAAAAAAAAAAAA&name=default",
+                "curl_command": "curl \"http://csrf/fake_protected_form.php\" -e \"http://csrf/fake_protected_form.php\" -d \"csrf_token=AAAAAAAAAAAAAAA&name=default\"",
                 "wstg": [
                     "WSTG-SESS-05"
                 ],
@@ -24,14 +24,14 @@
             },
             {
                 "method": "POST",
-                "path": "/fake_protected_form.php",
-                "info": "CSRF token 'csrf_token' might be easy to predict",
+                "path": "/unprotected_form.php",
+                "info": "Lack of anti CSRF token",
                 "level": 2,
                 "parameter": "",
-                "referer": "http://csrf/fake_protected_form.php",
+                "referer": "http://csrf/unprotected_form.php",
                 "module": "csrf",
-                "http_request": "POST /fake_protected_form.php HTTP/1.1\ncontent-type: application/x-www-form-urlencoded, application/x-www-form-urlencoded\nhost: csrf\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\nreferer: http://csrf/fake_protected_form.php\ncookie: PHPSESSID=1335df1b1b4a214\ncontent-length: 39\nContent-Type: application/x-www-form-urlencoded\n\ncsrf_token=AAAAAAAAAAAAAAA&name=default",
-                "curl_command": "curl \"http://csrf/fake_protected_form.php\" -e \"http://csrf/fake_protected_form.php\" -d \"csrf_token=AAAAAAAAAAAAAAA&name=default\"",
+                "http_request": "POST /unprotected_form.php HTTP/1.1\nhost: csrf\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\ncontent-type: application/x-www-form-urlencoded\nreferer: http://csrf/unprotected_form.php\ncookie: PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932\ncontent-length: 12\nContent-Type: application/x-www-form-urlencoded\n\nname=default",
+                "curl_command": "curl \"http://csrf/unprotected_form.php\" -e \"http://csrf/unprotected_form.php\" -d \"name=default\"",
                 "wstg": [
                     "WSTG-SESS-05"
                 ],
@@ -70,7 +70,7 @@
         "version": "Wapiti 3.1.7",
         "scope": "folder",
         "auth": null,
-        "crawled_pages_nbr": 8,
+        "crawled_pages_nbr": 7,
         "crawled_pages": [
             {
                 "request": {
@@ -130,6 +130,186 @@
                         [
                             "content-length",
                             "198"
+                        ],
+                        [
+                            "keep-alive",
+                            "timeout=5, max=100"
+                        ],
+                        [
+                            "connection",
+                            "Keep-Alive"
+                        ],
+                        [
+                            "content-type",
+                            "text/html; charset=UTF-8"
+                        ]
+                    ]
+                }
+            },
+            {
+                "request": {
+                    "url": "http://csrf/protected_form.php",
+                    "method": "GET",
+                    "headers": [
+                        [
+                            "host",
+                            "csrf"
+                        ],
+                        [
+                            "connection",
+                            "keep-alive"
+                        ],
+                        [
+                            "user-agent",
+                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
+                        ],
+                        [
+                            "accept-language",
+                            "en-US"
+                        ],
+                        [
+                            "accept-encoding",
+                            "gzip, deflate, br"
+                        ],
+                        [
+                            "accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+                        ]
+                    ],
+                    "referer": "",
+                    "enctype": "",
+                    "encoding": "UTF-8",
+                    "depth": 1
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": "<!DOCTYPE html><html><head>\t<meta charset=\"UTF-8\">\t<title>CSRF protected test</title></head><body>    <form method=\"POST\">    <label for=\"name\">Name:</label>    <input type=\"hidden\" name=\"csrf_token\" value=\"6ff3e3f37433c2bd7577186a974603840303aaa67258abaefce298943b223581\">    <input type=\"text\" id=\"name\" name=\"name\"><br><br>    <input type=\"submit\" value=\"Update\">    </form></body></html>",
+                    "headers": [
+                        [
+                            "server",
+                            "Apache/2.4.56 (Debian)"
+                        ],
+                        [
+                            "x-powered-by",
+                            "PHP/8.1.18"
+                        ],
+                        [
+                            "set-cookie",
+                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932; path=/"
+                        ],
+                        [
+                            "expires",
+                            "Thu, 19 Nov 1981 08:52:00 GMT"
+                        ],
+                        [
+                            "cache-control",
+                            "no-store, no-cache, must-revalidate"
+                        ],
+                        [
+                            "pragma",
+                            "no-cache"
+                        ],
+                        [
+                            "vary",
+                            "Accept-Encoding"
+                        ],
+                        [
+                            "content-encoding",
+                            "gzip"
+                        ],
+                        [
+                            "content-length",
+                            "276"
+                        ],
+                        [
+                            "keep-alive",
+                            "timeout=5, max=99"
+                        ],
+                        [
+                            "connection",
+                            "Keep-Alive"
+                        ],
+                        [
+                            "content-type",
+                            "text/html; charset=UTF-8"
+                        ]
+                    ]
+                }
+            },
+            {
+                "request": {
+                    "url": "http://csrf/unprotected_form.php",
+                    "method": "GET",
+                    "headers": [
+                        [
+                            "host",
+                            "csrf"
+                        ],
+                        [
+                            "connection",
+                            "keep-alive"
+                        ],
+                        [
+                            "user-agent",
+                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
+                        ],
+                        [
+                            "accept-language",
+                            "en-US"
+                        ],
+                        [
+                            "accept-encoding",
+                            "gzip, deflate, br"
+                        ],
+                        [
+                            "accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+                        ]
+                    ],
+                    "referer": "",
+                    "enctype": "",
+                    "encoding": "UTF-8",
+                    "depth": 1
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": "<!DOCTYPE html>\n<html>\n<head>\n\t<meta charset=\"UTF-8\">\n\t<title>CSRF unprotected test</title>\n</head>\n<body>\n    <form method=\"post\">\n    <label for=\"name\">Name:</label>\n    <input type=\"text\" id=\"name\" name=\"name\"><br><br>\n    <input type=\"submit\" value=\"Update\">\n    </form>\n</body>\n</html>\n\n",
+                    "headers": [
+                        [
+                            "server",
+                            "Apache/2.4.56 (Debian)"
+                        ],
+                        [
+                            "x-powered-by",
+                            "PHP/8.1.18"
+                        ],
+                        [
+                            "set-cookie",
+                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5; path=/"
+                        ],
+                        [
+                            "expires",
+                            "Thu, 19 Nov 1981 08:52:00 GMT"
+                        ],
+                        [
+                            "cache-control",
+                            "no-store, no-cache, must-revalidate"
+                        ],
+                        [
+                            "pragma",
+                            "no-cache"
+                        ],
+                        [
+                            "vary",
+                            "Accept-Encoding"
+                        ],
+                        [
+                            "content-encoding",
+                            "gzip"
+                        ],
+                        [
+                            "content-length",
+                            "206"
                         ],
                         [
                             "keep-alive",
@@ -223,7 +403,219 @@
                         ],
                         [
                             "keep-alive",
-                            "timeout=5, max=99"
+                            "timeout=5, max=100"
+                        ],
+                        [
+                            "connection",
+                            "Keep-Alive"
+                        ],
+                        [
+                            "content-type",
+                            "text/html; charset=UTF-8"
+                        ]
+                    ]
+                }
+            },
+            {
+                "request": {
+                    "url": "http://csrf/protected_form.php",
+                    "method": "POST",
+                    "headers": [
+                        [
+                            "host",
+                            "csrf"
+                        ],
+                        [
+                            "connection",
+                            "keep-alive"
+                        ],
+                        [
+                            "user-agent",
+                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
+                        ],
+                        [
+                            "accept-language",
+                            "en-US"
+                        ],
+                        [
+                            "accept-encoding",
+                            "gzip, deflate, br"
+                        ],
+                        [
+                            "accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+                        ],
+                        [
+                            "content-type",
+                            "application/x-www-form-urlencoded"
+                        ],
+                        [
+                            "referer",
+                            "http://csrf/protected_form.php"
+                        ],
+                        [
+                            "cookie",
+                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932"
+                        ],
+                        [
+                            "content-length",
+                            "88"
+                        ]
+                    ],
+                    "referer": "http://csrf/protected_form.php",
+                    "enctype": "application/x-www-form-urlencoded",
+                    "encoding": "utf-8",
+                    "depth": 2
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": "<!DOCTYPE html><html><head>\t<meta charset=\"UTF-8\">\t<title>CSRF protected test</title></head><body>    <form method=\"POST\">    <label for=\"name\">Name:</label>    <input type=\"hidden\" name=\"csrf_token\" value=\"6ff3e3f37433c2bd7577186a974603840303aaa67258abaefce298943b223581\">    <input type=\"text\" id=\"name\" name=\"name\"><br><br>    <input type=\"submit\" value=\"Update\">    </form></body></html>form submitted !",
+                    "headers": [
+                        [
+                            "server",
+                            "Apache/2.4.56 (Debian)"
+                        ],
+                        [
+                            "x-powered-by",
+                            "PHP/8.1.18"
+                        ],
+                        [
+                            "set-cookie",
+                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932; path=/"
+                        ],
+                        [
+                            "expires",
+                            "Thu, 19 Nov 1981 08:52:00 GMT"
+                        ],
+                        [
+                            "cache-control",
+                            "no-store, no-cache, must-revalidate"
+                        ],
+                        [
+                            "pragma",
+                            "no-cache"
+                        ],
+                        [
+                            "vary",
+                            "Accept-Encoding"
+                        ],
+                        [
+                            "content-encoding",
+                            "gzip"
+                        ],
+                        [
+                            "content-length",
+                            "282"
+                        ],
+                        [
+                            "keep-alive",
+                            "timeout=5, max=98"
+                        ],
+                        [
+                            "connection",
+                            "Keep-Alive"
+                        ],
+                        [
+                            "content-type",
+                            "text/html; charset=UTF-8"
+                        ]
+                    ]
+                }
+            },
+            {
+                "request": {
+                    "url": "http://csrf/unprotected_form.php",
+                    "method": "POST",
+                    "headers": [
+                        [
+                            "host",
+                            "csrf"
+                        ],
+                        [
+                            "connection",
+                            "keep-alive"
+                        ],
+                        [
+                            "user-agent",
+                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
+                        ],
+                        [
+                            "accept-language",
+                            "en-US"
+                        ],
+                        [
+                            "accept-encoding",
+                            "gzip, deflate, br"
+                        ],
+                        [
+                            "accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+                        ],
+                        [
+                            "content-type",
+                            "application/x-www-form-urlencoded"
+                        ],
+                        [
+                            "referer",
+                            "http://csrf/unprotected_form.php"
+                        ],
+                        [
+                            "cookie",
+                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932"
+                        ],
+                        [
+                            "content-length",
+                            "12"
+                        ]
+                    ],
+                    "referer": "http://csrf/unprotected_form.php",
+                    "enctype": "application/x-www-form-urlencoded",
+                    "encoding": "utf-8",
+                    "depth": 2
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": "form submitted !<!DOCTYPE html>\n<html>\n<head>\n\t<meta charset=\"UTF-8\">\n\t<title>CSRF unprotected test</title>\n</head>\n<body>\n    <form method=\"post\">\n    <label for=\"name\">Name:</label>\n    <input type=\"text\" id=\"name\" name=\"name\"><br><br>\n    <input type=\"submit\" value=\"Update\">\n    </form>\n</body>\n</html>\n\n",
+                    "headers": [
+                        [
+                            "server",
+                            "Apache/2.4.56 (Debian)"
+                        ],
+                        [
+                            "x-powered-by",
+                            "PHP/8.1.18"
+                        ],
+                        [
+                            "set-cookie",
+                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5; path=/"
+                        ],
+                        [
+                            "expires",
+                            "Thu, 19 Nov 1981 08:52:00 GMT"
+                        ],
+                        [
+                            "cache-control",
+                            "no-store, no-cache, must-revalidate"
+                        ],
+                        [
+                            "pragma",
+                            "no-cache"
+                        ],
+                        [
+                            "vary",
+                            "Accept-Encoding"
+                        ],
+                        [
+                            "content-encoding",
+                            "gzip"
+                        ],
+                        [
+                            "content-length",
+                            "215"
+                        ],
+                        [
+                            "keep-alive",
+                            "timeout=5, max=97"
                         ],
                         [
                             "connection",
@@ -275,7 +667,7 @@
                         ],
                         [
                             "cookie",
-                            "PHPSESSID=1335df1b1b4a214"
+                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932"
                         ],
                         [
                             "content-length",
@@ -329,358 +721,6 @@
                         ],
                         [
                             "keep-alive",
-                            "timeout=5, max=98"
-                        ],
-                        [
-                            "connection",
-                            "Keep-Alive"
-                        ],
-                        [
-                            "content-type",
-                            "text/html; charset=UTF-8"
-                        ]
-                    ]
-                }
-            },
-            {
-                "request": {
-                    "url": "http://csrf/protected_form.php",
-                    "method": "GET",
-                    "headers": [
-                        [
-                            "host",
-                            "csrf"
-                        ],
-                        [
-                            "connection",
-                            "keep-alive"
-                        ],
-                        [
-                            "user-agent",
-                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
-                        ],
-                        [
-                            "accept-language",
-                            "en-US"
-                        ],
-                        [
-                            "accept-encoding",
-                            "gzip, deflate, br"
-                        ],
-                        [
-                            "accept",
-                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
-                        ]
-                    ],
-                    "referer": "",
-                    "enctype": "",
-                    "encoding": "UTF-8",
-                    "depth": 1
-                },
-                "response": {
-                    "status_code": 200,
-                    "body": "<!DOCTYPE html><html><head>\t<meta charset=\"UTF-8\">\t<title>CSRF protected test</title></head><body>    <form method=\"POST\">    <label for=\"name\">Name:</label>    <input type=\"hidden\" name=\"csrf_token\" value=\"9043822b789c44d72175a57b4ae35aace401ae0c7384d6588aeaee3b9302eb71\">    <input type=\"text\" id=\"name\" name=\"name\"><br><br>    <input type=\"submit\" value=\"Update\">    </form></body></html>",
-                    "headers": [
-                        [
-                            "server",
-                            "Apache/2.4.56 (Debian)"
-                        ],
-                        [
-                            "x-powered-by",
-                            "PHP/8.1.18"
-                        ],
-                        [
-                            "set-cookie",
-                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932; path=/"
-                        ],
-                        [
-                            "expires",
-                            "Thu, 19 Nov 1981 08:52:00 GMT"
-                        ],
-                        [
-                            "cache-control",
-                            "no-store, no-cache, must-revalidate"
-                        ],
-                        [
-                            "pragma",
-                            "no-cache"
-                        ],
-                        [
-                            "vary",
-                            "Accept-Encoding"
-                        ],
-                        [
-                            "content-encoding",
-                            "gzip"
-                        ],
-                        [
-                            "content-length",
-                            "274"
-                        ],
-                        [
-                            "keep-alive",
-                            "timeout=5, max=100"
-                        ],
-                        [
-                            "connection",
-                            "Keep-Alive"
-                        ],
-                        [
-                            "content-type",
-                            "text/html; charset=UTF-8"
-                        ]
-                    ]
-                }
-            },
-            {
-                "request": {
-                    "url": "http://csrf/unprotected_form.php",
-                    "method": "GET",
-                    "headers": [
-                        [
-                            "host",
-                            "csrf"
-                        ],
-                        [
-                            "connection",
-                            "keep-alive"
-                        ],
-                        [
-                            "user-agent",
-                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
-                        ],
-                        [
-                            "accept-language",
-                            "en-US"
-                        ],
-                        [
-                            "accept-encoding",
-                            "gzip, deflate, br"
-                        ],
-                        [
-                            "accept",
-                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
-                        ]
-                    ],
-                    "referer": "",
-                    "enctype": "",
-                    "encoding": "UTF-8",
-                    "depth": 1
-                },
-                "response": {
-                    "status_code": 200,
-                    "body": "<!DOCTYPE html>\n<html>\n<head>\n\t<meta charset=\"UTF-8\">\n\t<title>CSRF unprotected test</title>\n</head>\n<body>\n    <form action=\"csrf_verify_unprotected.php\" method=\"post\">\n    <label for=\"name\">Name:</label>\n    <input type=\"text\" id=\"name\" name=\"name\"><br><br>\n    <input type=\"submit\" value=\"Update\">\n    </form>\n</body>\n</html>\n\n",
-                    "headers": [
-                        [
-                            "server",
-                            "Apache/2.4.56 (Debian)"
-                        ],
-                        [
-                            "x-powered-by",
-                            "PHP/8.1.18"
-                        ],
-                        [
-                            "set-cookie",
-                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5; path=/"
-                        ],
-                        [
-                            "expires",
-                            "Thu, 19 Nov 1981 08:52:00 GMT"
-                        ],
-                        [
-                            "cache-control",
-                            "no-store, no-cache, must-revalidate"
-                        ],
-                        [
-                            "pragma",
-                            "no-cache"
-                        ],
-                        [
-                            "vary",
-                            "Accept-Encoding"
-                        ],
-                        [
-                            "content-encoding",
-                            "gzip"
-                        ],
-                        [
-                            "content-length",
-                            "230"
-                        ],
-                        [
-                            "keep-alive",
-                            "timeout=5, max=100"
-                        ],
-                        [
-                            "connection",
-                            "Keep-Alive"
-                        ],
-                        [
-                            "content-type",
-                            "text/html; charset=UTF-8"
-                        ]
-                    ]
-                }
-            },
-            {
-                "request": {
-                    "url": "http://csrf/protected_form.php",
-                    "method": "POST",
-                    "headers": [
-                        [
-                            "host",
-                            "csrf"
-                        ],
-                        [
-                            "connection",
-                            "keep-alive"
-                        ],
-                        [
-                            "user-agent",
-                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
-                        ],
-                        [
-                            "accept-language",
-                            "en-US"
-                        ],
-                        [
-                            "accept-encoding",
-                            "gzip, deflate, br"
-                        ],
-                        [
-                            "accept",
-                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
-                        ],
-                        [
-                            "content-type",
-                            "application/x-www-form-urlencoded"
-                        ],
-                        [
-                            "referer",
-                            "http://csrf/protected_form.php"
-                        ],
-                        [
-                            "cookie",
-                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5"
-                        ],
-                        [
-                            "content-length",
-                            "88"
-                        ]
-                    ],
-                    "referer": "http://csrf/protected_form.php",
-                    "enctype": "application/x-www-form-urlencoded",
-                    "encoding": "utf-8",
-                    "depth": 2
-                },
-                "response": {
-                    "status_code": 200,
-                    "body": "<!DOCTYPE html><html><head>\t<meta charset=\"UTF-8\">\t<title>CSRF protected test</title></head><body>    <form method=\"POST\">    <label for=\"name\">Name:</label>    <input type=\"hidden\" name=\"csrf_token\" value=\"9043822b789c44d72175a57b4ae35aace401ae0c7384d6588aeaee3b9302eb71\">    <input type=\"text\" id=\"name\" name=\"name\"><br><br>    <input type=\"submit\" value=\"Update\">    </form></body></html>form submitted !",
-                    "headers": [
-                        [
-                            "server",
-                            "Apache/2.4.56 (Debian)"
-                        ],
-                        [
-                            "x-powered-by",
-                            "PHP/8.1.18"
-                        ],
-                        [
-                            "set-cookie",
-                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5fc3932; path=/"
-                        ],
-                        [
-                            "expires",
-                            "Thu, 19 Nov 1981 08:52:00 GMT"
-                        ],
-                        [
-                            "cache-control",
-                            "no-store, no-cache, must-revalidate"
-                        ],
-                        [
-                            "pragma",
-                            "no-cache"
-                        ],
-                        [
-                            "vary",
-                            "Accept-Encoding"
-                        ],
-                        [
-                            "content-encoding",
-                            "gzip"
-                        ],
-                        [
-                            "content-length",
-                            "280"
-                        ],
-                        [
-                            "keep-alive",
-                            "timeout=5, max=97"
-                        ],
-                        [
-                            "connection",
-                            "Keep-Alive"
-                        ],
-                        [
-                            "content-type",
-                            "text/html; charset=UTF-8"
-                        ]
-                    ]
-                }
-            },
-            {
-                "request": {
-                    "url": "http://csrf/csrf_verify_unprotected.php",
-                    "method": "GET",
-                    "headers": [
-                        [
-                            "host",
-                            "csrf"
-                        ],
-                        [
-                            "connection",
-                            "keep-alive"
-                        ],
-                        [
-                            "user-agent",
-                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
-                        ],
-                        [
-                            "accept-language",
-                            "en-US"
-                        ],
-                        [
-                            "accept-encoding",
-                            "gzip, deflate, br"
-                        ],
-                        [
-                            "accept",
-                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
-                        ],
-                        [
-                            "cookie",
-                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5"
-                        ]
-                    ],
-                    "referer": "",
-                    "enctype": "",
-                    "encoding": "UTF-8",
-                    "depth": 2
-                },
-                "response": {
-                    "status_code": 404,
-                    "body": "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p>The requested URL was not found on this server.</p>\n<hr>\n<address>Apache/2.4.56 (Debian) Server at csrf Port 80</address>\n</body></html>\n",
-                    "headers": [
-                        [
-                            "server",
-                            "Apache/2.4.56 (Debian)"
-                        ],
-                        [
-                            "content-length",
-                            "266"
-                        ],
-                        [
-                            "keep-alive",
                             "timeout=5, max=99"
                         ],
                         [
@@ -689,85 +729,7 @@
                         ],
                         [
                             "content-type",
-                            "text/html; charset=iso-8859-1"
-                        ]
-                    ]
-                }
-            },
-            {
-                "request": {
-                    "url": "http://csrf/csrf_verify_unprotected.php",
-                    "method": "POST",
-                    "headers": [
-                        [
-                            "host",
-                            "csrf"
-                        ],
-                        [
-                            "connection",
-                            "keep-alive"
-                        ],
-                        [
-                            "user-agent",
-                            "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
-                        ],
-                        [
-                            "accept-language",
-                            "en-US"
-                        ],
-                        [
-                            "accept-encoding",
-                            "gzip, deflate, br"
-                        ],
-                        [
-                            "accept",
-                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
-                        ],
-                        [
-                            "content-type",
-                            "application/x-www-form-urlencoded"
-                        ],
-                        [
-                            "referer",
-                            "http://csrf/unprotected_form.php"
-                        ],
-                        [
-                            "cookie",
-                            "PHPSESSID=1335df1b1b4a2149e8690c7ce5"
-                        ],
-                        [
-                            "content-length",
-                            "12"
-                        ]
-                    ],
-                    "referer": "http://csrf/unprotected_form.php",
-                    "enctype": "application/x-www-form-urlencoded",
-                    "encoding": "utf-8",
-                    "depth": 2
-                },
-                "response": {
-                    "status_code": 404,
-                    "body": "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p>The requested URL was not found on this server.</p>\n<hr>\n<address>Apache/2.4.56 (Debian) Server at csrf Port 80</address>\n</body></html>\n",
-                    "headers": [
-                        [
-                            "server",
-                            "Apache/2.4.56 (Debian)"
-                        ],
-                        [
-                            "content-length",
-                            "266"
-                        ],
-                        [
-                            "keep-alive",
-                            "timeout=5, max=99"
-                        ],
-                        [
-                            "connection",
-                            "Keep-Alive"
-                        ],
-                        [
-                            "content-type",
-                            "text/html; charset=iso-8859-1"
+                            "text/html; charset=UTF-8"
                         ]
                     ]
                 }

--- a/tests/integration/csrf/php/src/unprotected_form.php
+++ b/tests/integration/csrf/php/src/unprotected_form.php
@@ -13,7 +13,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
 	<title>CSRF unprotected test</title>
 </head>
 <body>
-    <form action="csrf_verify_unprotected.php" method="post">
+    <form method="post">
     <label for="name">Name:</label>
     <input type="text" id="name" name="name"><br><br>
     <input type="submit" value="Update">

--- a/tests/integration/docker-compose.setup.yml
+++ b/tests/integration/docker-compose.setup.yml
@@ -1,7 +1,7 @@
 services:
   # Apache server for the backup module
   backup:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./backup/html/:/var/www/html/
     networks:
@@ -10,7 +10,7 @@ services:
   # Wordpress database and wordpress container 
   # for the wp_enum
   wp_db:
-    image: mysql:8
+    image: ${MYSQL_HASH}
     volumes:
       - db_data:/var/lib/mysql
     restart: always
@@ -40,7 +40,7 @@ services:
 
   # Apache container for the brute_login_form module
   brute_login_form:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./brute_login_form/php/src:/var/www/html/
     networks:
@@ -48,7 +48,7 @@ services:
 
   # Apache container for the buster module
   buster:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./buster/php/src:/var/www/html/
     networks:
@@ -56,7 +56,7 @@ services:
 
   # Apache container for the cookieflags module
   cookieflags:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./cookieflags/php/src:/var/www/html/
     networks:
@@ -64,7 +64,7 @@ services:
 
   # Apache container for the crlf module
   crlf:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./crlf/php/src:/var/www/html/
     networks:
@@ -72,7 +72,7 @@ services:
 
   # Apache container for the csp module
   csp:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./csp/php/src:/var/www/html/
     networks:
@@ -80,7 +80,7 @@ services:
 
   # Apache container for the exec module
   exec:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./exec/php/src:/var/www/html/
     networks:
@@ -88,7 +88,7 @@ services:
 
   # Apache container for the file module
   file:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./file/php/src:/var/www/html/
     networks:
@@ -96,7 +96,6 @@ services:
 
   # Apache container for the htaccess module
   htaccess:
-    htaccess:
     build:
       context: ./htaccess/
       dockerfile: Dockerfile
@@ -107,76 +106,54 @@ services:
 
   # Apache container for the htp module
   htp:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./htp/php/src:/var/www/html/
     networks:
       - test-network
 
   # Drupal containers and their databases for the drupal_enum module
-  drupal8:
-    image: drupal:8-apache
-    networks:
-      - test-network
-    environment:
-      MYSQL_HOST: drupal8-db
-      MYSQL_DATABASE: drupal8
-      MYSQL_USER: drupal8
-      MYSQL_PASSWORD: drupal8pwd
-    depends_on:
-      - drupal8-db
-
-  drupal8-db:
-    image: mysql:8
-    environment:
-      MYSQL_DATABASE: drupal8
-      MYSQL_USER: drupal8
-      MYSQL_PASSWORD: drupal8pwd
-      MYSQL_ROOT_PASSWORD: rootpwd
-    networks:
-      - test-network
-
   drupal9:
-    image: drupal:9-apache
+    image: ${DRUPAL9_HASH}
     networks:
       - test-network
     environment:
       MYSQL_HOST: drupal9-db
-      MYSQL_DATABASE: drupal9
-      MYSQL_USER: drupal9
-      MYSQL_PASSWORD: drupal9pwd
+      MYSQL_DATABASE: ${DRUPAL_MYSQL_DB}
+      MYSQL_USER: ${DRUPAL_MYSQL_USER}
+      MYSQL_PASSWORD: ${DRUPAL_MYSQL_PASSWORD}
     depends_on:
       - drupal9-db
 
   drupal9-db:
-    image: mysql:8
+    image: ${MYSQL_HASH}
     environment:
-      MYSQL_DATABASE: drupal9
-      MYSQL_USER: drupal9
-      MYSQL_PASSWORD: drupal9pwd
-      MYSQL_ROOT_PASSWORD: rootpwd
+      MYSQL_DATABASE: ${DRUPAL_MYSQL_DB}
+      MYSQL_USER: ${DRUPAL_MYSQL_USER}
+      MYSQL_PASSWORD: ${DRUPAL_MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DRUPAL_MYSQL_ROOT_PASSWORD}
     networks:
       - test-network
 
   drupal10:
-    image: drupal:10-apache
+    image: ${DRUPAL10_HASH}
     networks:
       - test-network
     environment:
       MYSQL_HOST: drupal10-db
-      MYSQL_DATABASE: drupal10
-      MYSQL_USER: drupal10
-      MYSQL_PASSWORD: drupal10pwd
+      MYSQL_DATABASE: ${DRUPAL_MYSQL_DB}
+      MYSQL_USER: ${DRUPAL_MYSQL_USER}
+      MYSQL_PASSWORD: ${DRUPAL_MYSQL_PASSWORD}
     depends_on:
       - drupal10-db
 
   drupal10-db:
-    image: mysql:8
+    image: ${MYSQL_HASH}
     environment:
-      MYSQL_DATABASE: drupal10
-      MYSQL_USER: drupal10
-      MYSQL_PASSWORD: drupal10pwd
-      MYSQL_ROOT_PASSWORD: rootpwd
+      MYSQL_DATABASE: ${DRUPAL_MYSQL_DB}
+      MYSQL_USER: ${DRUPAL_MYSQL_USER}
+      MYSQL_PASSWORD: ${DRUPAL_MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DRUPAL_MYSQL_ROOT_PASSWORD}
     networks:
       - test-network
 
@@ -192,7 +169,7 @@ services:
 
   # Apache container for the log4shell module
   log4shell:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./log4shell/php/src:/var/www/html/
     networks:
@@ -200,7 +177,7 @@ services:
 
   # Apache container for the methods module
   methods:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./methods/php/src:/var/www/html/
     networks:
@@ -208,7 +185,7 @@ services:
 
   # Apache container for the nikto module
   nikto:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./nikto/php/src:/var/www/html/
     networks:
@@ -216,7 +193,7 @@ services:
 
   # Apache container for the permanentxss module
   permanentxss:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./permanentxss/php/src:/var/www/html/
     networks:
@@ -224,7 +201,7 @@ services:
 
   # Apache container for the xxe module
   xxe:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./xxe/php/src/:/var/www/html/
     networks:
@@ -232,7 +209,7 @@ services:
 
   # Apache container for the shellshock module
   shellshock:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./shellshock/php/src:/var/www/html/
     networks:
@@ -240,7 +217,7 @@ services:
 
   # Apache container for the sql module
   sql:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./sql/php/src:/var/www/html/
     networks:
@@ -248,7 +225,7 @@ services:
 
   # Apache container for the ssl module
   ssl:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./ssl/php/src:/var/www/html/
     networks:
@@ -256,7 +233,7 @@ services:
 
   # Apache container for the ssrf module
   ssrf:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./ssrf/php/src:/var/www/html/
     networks:
@@ -264,7 +241,7 @@ services:
 
   # Apache container for the takeover module
   takeover:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./takeover/php/src:/var/www/html/
     networks:
@@ -272,7 +249,7 @@ services:
 
   # Apache container for the timesql module
   timesql:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./timesql/php/src:/var/www/html/
     networks:
@@ -280,7 +257,7 @@ services:
 
   # Apache container for the wapp module
   wapp:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./wapp/php/src:/var/www/html/
     networks:
@@ -288,7 +265,7 @@ services:
 
   # Apache container for the xss module
   xss:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./xss/php/src:/var/www/html/
     networks:
@@ -296,7 +273,7 @@ services:
 
   # Apache container for the csrf module
   csrf:
-    image: php:8.1-apache
+    image: ${PHP_HASH}
     volumes:
       - ./csrf/php/src:/var/www/html/
     networks:
@@ -326,8 +303,6 @@ services:
       - file
       - htaccess
       - htp
-      - drupal8
-      - drupal8-db
       - drupal9
       - drupal9-db
       - drupal10

--- a/tests/integration/htaccess/Dockerfile
+++ b/tests/integration/htaccess/Dockerfile
@@ -1,4 +1,8 @@
-FROM php:8.1.18-apache
+# The following hash corresponds to the image php:8.1.18-apache
+# php@sha256:5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471
+# it can be found here: https://hub.docker.com/layers/library/php/8.1.18-apache/images/sha256-5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471?context=explore
+
+FROM php@sha256:5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471
 
 RUN /usr/sbin/a2enmod rewrite
 

--- a/tests/integration/http_headers/Dockerfile
+++ b/tests/integration/http_headers/Dockerfile
@@ -1,4 +1,8 @@
-FROM php:8.1.18-apache
+# The following hash corresponds to the image php:8.1.18-apache
+# php@sha256:5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471
+# it can be found here: https://hub.docker.com/layers/library/php/8.1.18-apache/images/sha256-5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471?context=explore
+
+FROM php@sha256:5d5f0dbea68afab7e6fa7649fb818e078680e338a3265ec5cf237a6a791dd471
 EXPOSE 443 80 
 
 RUN apt-get update -y && \

--- a/tests/integration/modules.json
+++ b/tests/integration/modules.json
@@ -76,7 +76,6 @@
     {
         "module": "drupal_enum",
         "targets": [
-            "drupal8",
             "drupal9",
             "drupal10"
         ]

--- a/tests/integration/test.py
+++ b/tests/integration/test.py
@@ -5,6 +5,7 @@ import requests
 import re
 from itertools import cycle
 from collections import defaultdict
+from time import sleep
 
 
 def purge_irrelevant_data(data):
@@ -55,7 +56,7 @@ total_targets = sum([len(mod["targets"]) for mod in modules_data])
 # started well, this is another way to fill the set to break
 # the loop
 requests_counter = defaultdict(int)
-MAX_REQ = 50
+MAX_REQ = 500
 
 # Running wapiti for each module for each target
 # If a target isn't set up, passing to another and so on
@@ -90,13 +91,15 @@ for mod in iter_modules:
                     json.dump({
                         "vulnerabilities": bloated_output_data.get("vulnerabilities", {}),
                         "anomalies": bloated_output_data.get("anomalies", {}),
-                        "additionnals": bloated_output_data.get("additionnals", {}),
+                        "additionals": bloated_output_data.get("additionals", {}),
                         "infos": bloated_output_data.get("infos", {})
                     }, output_file, indent=4)
                 tested_targets.add(target)
             except requests.exceptions.ConnectionError:
                 sys.stdout.write(f"Target {target} is not ready yet...\n")
-                pass
+                # 0.5 seconds penalty in case of no response to avoid requests spamming and being
+                # too fast at blacklisting targets
+                sleep(0.5)
             if requests_counter[target] > MAX_REQ:
                 sys.stdout.write(
                     f"Target {target} from module {mod['module']} takes too long to respond\nSkipping...\n")


### PR DESCRIPTION
suppression d'une action partant vers une page n'existant plus dans le module CSRF causant un 404 not found reflété sur le rapport de Wapiti 

régénération de l'assertion du module CSRF suite à cette modification

utilisation des hashes a la place des tags pour plus de stabilité, ajouts de commentaires à ce propos

répétition du mot htaccess dans le docker compose file 