### PR TITLE
added integration tests to GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,3 +64,19 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  integrate:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Docker Compose
+        run: bash ${GITHUB_WORKSPACE}/tests/integration/run.sh 
+      
+      - name: Archive production artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: diff-reports-file
+          path: tests/integration/.dump_diff_file.txt

--- a/tests/integration/check.sh
+++ b/tests/integration/check.sh
@@ -62,6 +62,8 @@ if [[ ${#assertions[@]} -ne ${#targets_name[@]} || ${#targets_name[@]} -ne ${#ou
     die "Error: different number of reports/assertion files, found ${#outputs[@]} outputs for ${#assertions[@]} assertions"
 fi
 
+EXIT_CODE=0
+
 # Comparing outputs and assertions is a 2-steps process:
 for i in "${!outputs[@]}"; do
 
@@ -70,8 +72,9 @@ for i in "${!outputs[@]}"; do
         echo "< : assertion"
         echo "> : output"
         diff <(jq --sort-keys . "${outputs[$i]}") <(jq --sort-keys . "${assertions[$i]}") || echo "---End of diff of assertion $(basename "${assertions[$i]}" .json) module ${MODULE_NAME}---"
+        EXIT_CODE=1
     else 
         echo -e "Assertion $(basename "${assertions[$i]}" .json) of module $MODULE_NAME is ${GREEN}respected${NC}"
     fi 
 done
-exit 0
+exit $EXIT_CODE

--- a/tests/integration/docker-compose.setup.yml
+++ b/tests/integration/docker-compose.setup.yml
@@ -370,7 +370,7 @@ services:
       - ./.test:/home/
     networks:
       - test-network
-    command: "test_mod_backup test_mod_wp_enum test_mod_brute_login_form test_mod_cookieflags test_mod_crlf test_mod_csrf test_mod_csp test_mod_exec test_mod_file test_mod_htaccess test_mod_drupal_enum test_mod_http_headers test_mod_xxe test_mod_xss test_mod_sql test_mod_shellshock test_mod_methods test_mod_timesql test_crawler_auth"
+    command: "${TESTS}"
     depends_on:
       backup:
         condition: service_healthy

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1,26 +1,116 @@
 #!/bin/bash
 
+# List of all the tests
+# TESTS="test_mod_backup \
+# test_mod_brute_login_form \
+# test_mod_cookieflags \
+# test_mod_crlf \
+# test_mod_csp \
+# test_mod_csrf \
+# test_mod_exec \
+# test_mod_file \
+# test_mod_htaccess \
+# test_mod_drupal_enum \
+# test_mod_http_headers \
+# test_mod_methods \
+# test_mod_shellshock \
+# test_mod_sql \
+# test_mod_timeslq \
+# test_mod_wp_enum \
+# test_mod_xss \
+# test_mod_xxe \
+# test_crawler_auth \
+# test_crawler_redirect "
+
+# List of the currently working tests
+TESTS="test_mod_backup \
+test_mod_wp_enum \
+test_mod_brute_login_form \
+test_mod_cookieflags \
+test_mod_crlf \
+test_mod_csrf \
+test_mod_csp \
+test_mod_exec \
+test_mod_file \
+test_mod_htaccess \
+test_mod_http_headers \
+test_mod_xxe \
+test_mod_xss \
+test_mod_sql \
+test_mod_shellshock \
+test_mod_methods \
+test_mod_timesql \
+test_crawler_auth "
+
+# Normalize trailing space for shell substitution
+if [[ ! -z "$TESTS" ]]; then
+    export TESTS="${TESTS%% } "
+fi
+
 # exit upon any error
 set -o errexit
 
 # exit upon using undeclared variables
 set -o nounset
 
-# Cleaning docker
-docker kill $(docker ps -q) || echo "no containers to kill"
-docker container prune -f || echo "no containers to prune"
-docker volume prune -f || echo "no volumes to prune"
-docker rmi $(docker images -a -q) || echo "no images to remove"
-(docker system prune -f && docker network create test-network) || echo "no need to prune the system"
+# Placing ourselves in the right directory
+cd "$(dirname "$0")"
 
-time docker compose -f docker-compose.setup.yml up --abort-on-container-exit 
+# Parsing script arguments 
+declare -A args
+for arg in "$@"; do
+    args[$arg]=1;
+done; 
 
-# will do some checks only where assertions files exist
+if [[ -v args["--help"] ]]; then
+    # Printing some help
+    printf "%s\n" \
+           "Entrypoint to run integration tests" \
+           "Usage: ./run.sh [options]" \
+           "Options:" \
+           "    --help           Display this message and exit"\
+           "    --docker-clean   Kill containers, remove and prune all docker images, volumes, and system, be carefull when using this option"\
+           "    --verbose-build  Print the build messages before running the tests";
+           exit 0;
+fi
+
+if [[ -v args["--docker-clean"] ]]; then
+    # Cleaning docker
+    docker kill $(docker ps -q) || echo "no containers to kill"
+    docker container prune -f || echo "no containers to prune"
+    docker volume prune -f || echo "no volumes to prune"
+    docker rmi $(docker images -a -q) || echo "no images to remove"
+    (docker system prune -f && docker network create test-network) || echo "no need to prune the system"
+fi
+
+# Fallback to create the test-network in case it doesn't exist
+docker network inspect test-network > /dev/null || docker network create test-network > /dev/null
+
+if [[ ! -v args["--verbose-build"] ]];then
+# Quietly build all Dockerfiles
+docker compose -f docker-compose.setup.yml build --quiet
+fi
+
+# Start the tests
+docker compose  --progress quiet -f docker-compose.setup.yml up --abort-on-container-exit
+
 declare -a asserters=()
-mapfile -t asserters < <(find . -mindepth 2 -type d -name assertions)
-
+# If the TESTS env variable is supplied, we will only check the specified tests
+if [[ ! -z "$TESTS" ]]; then
+    # Assuming all the tests in the TESTS variable are well written and exist
+    mapfile -t asserters < <(echo -e "${TESTS// /\/assertions\/check.sh\\n}" |  head -n -1)
+else
+    # Otherwise, we take all the tests
+    mapfile -t asserters < <(find . -mindepth 2 -type l,f -name check.sh)
+fi
+EXIT_CODE=0
 for path in "${asserters[@]}"; do
-    cd "${path}" 
-    bash "check.sh" || echo "assertion ${path} not ready, skipping"
+    cd "$(dirname "${path}")" 
+    bash "check.sh" | tee -a ../../.dump_diff_file.txt
+    # Workaround to check if check.sh succeed, may not work on zsh 
+    if [[ "${PIPESTATUS[0]}" -eq 1 ]]; then
+        EXIT_CODE=1
+    fi
     cd - > /dev/null 
 done
+exit $EXIT_CODE

--- a/tests/integration/test_mod_http_headers/Dockerfile
+++ b/tests/integration/test_mod_http_headers/Dockerfile
@@ -2,10 +2,10 @@ ARG PHP_HASH_TAG=':8.1-apache'
 FROM php${PHP_HASH_TAG}
 EXPOSE 443 80 
 
-RUN apt-get update -y && \
-    apt-get install openssl -y && \
-    apt-get clean -yq && \
-    apt-get -y autoremove -yq && \
+RUN apt-get -y update && \
+    apt-get -y install openssl -y && \
+    apt-get -y clean && \
+    apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     truncate -s 0 /var/log/*log
 

--- a/tests/integration/test_mod_shellshock/Dockerfile
+++ b/tests/integration/test_mod_shellshock/Dockerfile
@@ -5,10 +5,10 @@ COPY  packages /packages
 COPY ./html/src/index.html /usr/local/apache2/htdocs/index.html
 COPY ./vuln.cgi /usr/local/apache2/cgi-bin/vuln.cgi 
 
-RUN apt update &&\
-    apt install -f /packages/* curl -y --allow-downgrades &&\
-    apt clean -yq &&\
-    apt autoremove -yq &&\
+RUN apt-get -y update &&\
+    apt-get -y install -f /packages/* curl --allow-downgrades &&\
+    apt-get -y clean &&\
+    apt-get -y autoremove &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
     truncate -s 0 /var/log/*log
 

--- a/tests/integration/test_mod_wp_enum/Dockerfile
+++ b/tests/integration/test_mod_wp_enum/Dockerfile
@@ -4,12 +4,12 @@ FROM wordpress${WP_HASH_TAG}
 ENV DEPENDENCIES "curl unzip"
 
 # Install zip utility
-RUN apt-get update -y &&\
-    apt-get install ${DEPENDENCIES} -y &&\  
-    apt-get dist-upgrade -y &&\
-    apt-get upgrade -y &&\
-    apt-get -y autoremove &&\
-    apt-get clean 
+RUN apt-get -yqq update &&\
+    apt-get -yqq install ${DEPENDENCIES} &&\  
+    apt-get -yqq dist-upgrade &&\
+    apt-get -yqq upgrade &&\
+    apt-get -yqq autoremove &&\
+    apt-get -yqq clean 
 
 
 # Install Contact Form 7 plugin

--- a/tests/integration/wapiti/Dockerfile.integration
+++ b/tests/integration/wapiti/Dockerfile.integration
@@ -5,11 +5,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 WORKDIR /usr/src/app
 
-RUN apt update &&\
-  apt install -y --no-install-recommends\
-  python3 python3-pip python3-setuptools ca-certificates -y &&\
-  apt clean -yq &&\
-  apt autoremove -yq &&\
+RUN apt-get -y update &&\
+  apt-get -y install --no-install-recommends\
+  python3 python3-pip python3-setuptools ca-certificates &&\
+  apt-get -y clean &&\
+  apt-get -y autoremove &&\
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
   truncate -s 0 /var/log/*log
 
@@ -24,11 +24,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8 \
   PYTHONDONTWRITEBYTECODE=1
 
-RUN apt update &&\
-  apt install -y --no-install-recommends \
+RUN apt-get -y update &&\
+  apt-get -y install --no-install-recommends \
   python3 python3-setuptools curl &&\
-  apt clean -yq &&\
-  apt autoremove -yq &&\
+  apt-get -y clean &&\
+  apt-get -y autoremove &&\
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
   truncate -s 0 /var/log/*log
 

--- a/tests/integration/wapiti/modules.json
+++ b/tests/integration/wapiti/modules.json
@@ -210,7 +210,7 @@
                 "name": "http://csp/index.php"
             },
             {
-                "name": "http://csp/csp_secured.php}"
+                "name": "http://csp/csp_secured.php"
             }
         ]
     },


### PR DESCRIPTION
Intégration du système de test d'intégration dans la CI de Github action.
En cas d'échec ou de réussite, les logs sont sauvés en tant qu'artifact GitHub et loggé dans la CI en tant que différences entre fichiers rapports/assertions. Si une assertion n'est pas respectée, le code va continuer à s'exécuter mais retournera tout de même un exit code différent de 0.
exemple d'échec :
![Capture d'écran 2023-07-17 143948](https://github.com/RMI78/wapiti/assets/26175239/75f0916b-b74c-42ba-9a25-3b52e805f3c6)
https://github.com/RMI78/wapiti/actions/runs/5584588389
exemple de reussite :
![Capture d'écran 2023-07-17 173750](https://github.com/RMI78/wapiti/assets/26175239/0572a888-f949-4c84-beb4-88e801095912)
https://github.com/RMI78/wapiti/actions/runs/5577623887/jobs/10190639693


Pour passer par cela, il a fallu creer et exporter une variable d'environement TESTS (déclaré et exporté au début de run.sh qui contient les tests d'intégrations séparé par des espaces) 

Correction d'une typo dans module.json qui créait un bug et empéchait Wapiti d'attaquer la bonne cible

Ajout d'un mode verbose en build dans run.sh et modification des dockerfiles pour qu'ils soient tous verbeux. Cette option est accessible par le flag ``--verbose-build``
Passage du nettoyage de docker en option grace au flag ``--docker-clean``
Ajout d'un flag d'aide ``--help`` pour les autres flags 